### PR TITLE
ci: add workflow for merging SQLite databases

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,53 @@
+name: Merge database
+
+on:
+    workflow_dispatch:
+        inputs:
+            source_run_id:
+                description: "Run ID of the workflow containing the source SQLite artifact"
+                required: true
+                type: string
+            target_run_id:
+                description: "Run ID of the workflow containing the target SQLite artifact"
+                required: true
+                type: string
+
+jobs:
+    merge-sqlite:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out this repo
+              uses: actions/checkout@v4
+
+            - name: Set up python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: 3.11
+
+            - name: Download source artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: ca-fires-history-db
+                  path: ./
+                  run-id: ${{ inputs.source_run_id }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+              continue-on-error: false
+
+            - name: Download target artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: ca-fires-history-db
+                  path: ./data/
+                  run-id: ${{ inputs.target_run_id }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+              continue-on-error: false
+
+            - name: Merge SQLite databases
+              run: python3 merge.py
+
+            - name: Reupload artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: ca-fires-history-db
+                  path: ./data/fires.db
+                  if-no-files-found: error

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,4 +1,13 @@
-name: Merge database
+name: Merge sqlite
+
+# This GitHub Actions workflow merges two SQLite databases manually to synchronize data that may have diverged.
+#
+# Usage:
+# 1. Trigger this workflow manually using the GitHub Actions workflow dispatch feature.
+# 2. Specify the run IDs of the workflows containing the source and target SQLite artifacts.
+#    To obtain the run IDs:
+#    - Use the GitHub API endpoint `https://api.github.com/repos/{owner}/{repo}/actions/artifacts?per_page=10`
+#    - Retrieve the `workflow_run.id` from the list of artifacts. This ID corresponds to the workflow run that produced the SQLite artifact.
 
 on:
     workflow_dispatch:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -10,6 +10,7 @@ name: Merge sqlite
 #    - Retrieve the `workflow_run.id` from the list of artifacts. This ID corresponds to the workflow run that produced the SQLite artifact.
 
 on:
+    push:
     workflow_dispatch:
         inputs:
             source_run_id:

--- a/merge.py
+++ b/merge.py
@@ -1,0 +1,35 @@
+import sqlite3
+
+
+def merge_databases(source_db_path, target_db_path, table_name):
+    source_conn = sqlite3.connect(source_db_path)
+    target_conn = sqlite3.connect(target_db_path)
+
+    source_cursor = source_conn.cursor()
+    target_cursor = target_conn.cursor()
+
+    source_cursor.execute(f"SELECT * FROM {table_name}")
+    source_records = source_cursor.fetchall()
+
+    for record in source_records:
+        unique_id = record[0]
+        target_cursor.execute(
+            f"SELECT 1 FROM {table_name} WHERE UniqueId=?", (unique_id,)
+        )
+        exists = target_cursor.fetchone()
+
+        if exists:
+            continue
+
+        target_cursor.execute(
+            f"INSERT INTO {table_name} VALUES ({','.join(['?']*len(record))})",
+            record,
+        )
+
+    target_conn.commit()
+    target_conn.close()
+    source_conn.close()
+
+
+if __name__ == "__main__":
+    merge_databases("fires.db", "data/fires.db", "incidents")


### PR DESCRIPTION
> Will not merge. This branch serves as a testing ground for manually merging two sqlite databases in the event that the original database becomes corrupted or lost. This will allow us to retrieve the most recent reliable version and merge it with any newer versions of the database to avoid data loss.

Instructions:

1. It is necessary to include a `push` event to 'register' this workflow on this new branch
2. To execute this, you will need to run it using the `gh` CLI, for example:
    ```sh
    gh workflow run 'Merge sqlite' --ref merge-db -f source_run_id=9955939084  -f target_run_id=9975170416
    ```
