### PR TITLE
ci: fix deploy job to railway

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -78,15 +78,25 @@ jobs:
             - name: Check out this repo
               uses: actions/checkout@v4
 
-            - name: Set up Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: "20"
+            - name: Get Latest Deployment ID
+              id: get-deployment
+              run: |
+                  DEPLOYMENT_ID=$(curl -X POST \
+                    -H "Content-Type: application/json" \
+                    -H "Authorization: Bearer ${{ secrets.RAILWAY_TOKEN }}" \
+                    -d '{
+                      "query": "query deployments { deployments(last: 1, input: { serviceId: \"${{ secrets.RAILWAY_SERVICE_ID }}\", status: { in: [SUCCESS] } }) { edges { node { id status } } } }"
+                    }' \
+                    https://backboard.railway.com/graphql/v2 | \
+                    jq -r '.data.deployments.edges[0].node.id')
+                  echo "deployment_id=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
 
-            - name: Install Railway CLI
-              run: npm install -g @railway/cli
-
-            - name: Deploy to Railway
-              env:
-                  RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-              run: railway up --service=${{ secrets.RAILWAY_SERVICE_ID }}
+            - name: Trigger Redeployment
+              run: |
+                  curl -X POST \
+                    -H "Content-Type: application/json" \
+                    -H "Authorization: Bearer ${{ secrets.RAILWAY_TOKEN }}" \
+                    -d '{
+                      "query": "mutation { deploymentRedeploy(id: \"${{ steps.get-deployment.outputs.deployment_id }}\", usePreviousImageTag: true) { id status } }"
+                    }' \
+                    https://backboard.railway.com/graphql/v2

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ This project is inspired by and adapts the work from [simonw/ca-fires-history](h
 
 ```mermaid
 graph TB
-	subgraph Vercel
+	subgraph Railway
         deployment[Datasette]
-        class deployment vercel;
+        class deployment Railway;
     end
 
     subgraph GitHub


### PR DESCRIPTION
# Redeploying Docker Images on Railway.app

`railway up` doesn't work for Docker image redeployments - it attempts to build with nixpacks instead of using the Docker image.

See: https://discord.com/channels/713503345364697088/1156086954815918080

I found two working solutions:

## Method 1: Dashboard Redeploy

I can manually redeploy from Railway's dashboard. While effective for immediate needs, this isn't sustainable for automation.

## Method 2: Railway API

Implement an automated solution using Railway's API. Here's my approach:

1. I query for the last successful deployment ID:
```graphql
query deployments {
    deployments(
        last: 1
        input: {
            projectId: "YOUR_PROJECT_ID"
            environmentId: "YOUR_ENVIRONMENT_ID"
            serviceId: "YOUR_SERVICE_ID"
            status: { in: [SUCCESS] }
        }
    ) {
        edges {
            node {
                id
                status
            }
        }
    }
}
```

2. I use this ID to trigger a redeployment:
```graphql
mutation {
    deploymentRedeploy(
        id: "DEPLOYMENT_ID_FROM_STEP_1"
        usePreviousImageTag: true
    ) {
        id
        status
    }
}
```